### PR TITLE
Fixed Non-deterministic behavior of HashSet that might fail the test in `ClientLibrariesImplTest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For existing projects, take example from the [AEM Project Archetype](https://git
 
 Core Components | AEM as a Cloud Service | AEM 6.5   | Java SE | Maven
 ----------------|------------------------|-----------|---------|---------
-[2.23.4](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.23.4) | Continual | 6.5.17.0+ | 8, <br/>11 | 3.3.9+
+[2.23.5+](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.23.4) | Continual | 6.5.19.0+ | 8, <br/>11 | 3.3.9+
 
 For the requirements from previous Core Component releases, see [Historical System Requirements](VERSIONS.md).
 

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -528,7 +528,6 @@
             <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
@@ -297,7 +297,7 @@ public class ClientLibrariesImpl implements ClientLibraries {
     @NotNull
     protected Set<String> getCategoriesFromComponents() {
         try (ResourceResolver resourceResolver = resolverFactory.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, COMPONENTS_SERVICE))) {
-            Set<String> categories = new HashSet<>();
+            Set<String> categories = new LinkedHashSet<>();
             for (ClientLibrary library : this.getAllClientLibraries(resourceResolver)) {
                 for (String category : library.getCategories()) {
                     if (pattern == null || pattern.matcher(category).matches()) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/util/LocalizationUtils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/util/LocalizationUtils.java
@@ -97,7 +97,7 @@ public class LocalizationUtils {
             if (relationshipManager.isSource(resource)) {
                 // the resource is a blueprint
                 RangeIterator liveCopiesIterator = relationshipManager.getLiveRelationships(resource, null, null);
-                if (liveCopiesIterator != null) {
+                if (liveCopiesIterator != null && liveCopiesIterator.hasNext()) {
                     LiveRelationship relationship = (LiveRelationship) liveCopiesIterator.next();
                     LiveCopy liveCopy = relationship.getLiveCopy();
                     if (liveCopy != null) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
@@ -53,6 +53,7 @@ import com.day.cq.wcm.api.PageManager;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -456,12 +457,18 @@ class ClientLibrariesImplTest {
             add("core/wcm/components/carousel/v3/carousel");
         }});
         ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, attributes);
-        StringBuilder includes = new StringBuilder();
-        includes.append(jsIncludes.get(ACCORDION_CATEGORY));
-        includes.append(jsIncludes.get(CAROUSEL_CATEGORY));
-        includes.append(cssIncludes.get(ACCORDION_CATEGORY));
-        includes.append(cssIncludes.get(CAROUSEL_CATEGORY));
-        assertEquals(includes.toString(), clientlibs.getJsAndCssIncludes());
+        String actual = clientlibs.getJsAndCssIncludes();
+        StringBuilder includes1 = new StringBuilder();
+        includes1.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes1.append(jsIncludes.get(CAROUSEL_CATEGORY));
+        includes1.append(cssIncludes.get(ACCORDION_CATEGORY));
+        includes1.append(cssIncludes.get(CAROUSEL_CATEGORY));
+        StringBuilder includes2 = new StringBuilder();
+        includes2.append(jsIncludes.get(CAROUSEL_CATEGORY));
+        includes2.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes2.append(cssIncludes.get(CAROUSEL_CATEGORY));
+        includes2.append(cssIncludes.get(ACCORDION_CATEGORY));
+        assertTrue((includes1.toString().equals(actual)) || (includes2.toString().equals(actual)));
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
@@ -53,7 +53,6 @@ import com.day.cq.wcm.api.PageManager;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -457,18 +456,12 @@ class ClientLibrariesImplTest {
             add("core/wcm/components/carousel/v3/carousel");
         }});
         ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, attributes);
-        String actual = clientlibs.getJsAndCssIncludes();
-        StringBuilder includes1 = new StringBuilder();
-        includes1.append(jsIncludes.get(ACCORDION_CATEGORY));
-        includes1.append(jsIncludes.get(CAROUSEL_CATEGORY));
-        includes1.append(cssIncludes.get(ACCORDION_CATEGORY));
-        includes1.append(cssIncludes.get(CAROUSEL_CATEGORY));
-        StringBuilder includes2 = new StringBuilder();
-        includes2.append(jsIncludes.get(CAROUSEL_CATEGORY));
-        includes2.append(jsIncludes.get(ACCORDION_CATEGORY));
-        includes2.append(cssIncludes.get(CAROUSEL_CATEGORY));
-        includes2.append(cssIncludes.get(ACCORDION_CATEGORY));
-        assertTrue((includes1.toString().equals(actual)) || (includes2.toString().equals(actual)));
+        StringBuilder includes = new StringBuilder();
+        includes.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes.append(jsIncludes.get(CAROUSEL_CATEGORY));
+        includes.append(cssIncludes.get(ACCORDION_CATEGORY));
+        includes.append(cssIncludes.get(CAROUSEL_CATEGORY));
+        assertEquals(includes.toString(), clientlibs.getJsAndCssIncludes());
     }
 
     @Test

--- a/bundles/core/src/test/java/com/day/cq/wcm/foundation/forms/FormsHelper.java
+++ b/bundles/core/src/test/java/com/day/cq/wcm/foundation/forms/FormsHelper.java
@@ -20,7 +20,6 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestDispatcherOptions;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.commons.json.JSONException;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -183,9 +182,9 @@ public class FormsHelper {
         return null;
     }
 
-    public static void inlineValuesAsJson(SlingHttpServletRequest request, Writer out, String path) throws IOException, RepositoryException, JSONException {}
+    public static void inlineValuesAsJson(SlingHttpServletRequest request, Writer out, String path) throws IOException, RepositoryException {}
 
-    public static void inlineValuesAsJson(SlingHttpServletRequest request, Writer out, String path, int nodeDepth) throws IOException, RepositoryException, JSONException {}
+    public static void inlineValuesAsJson(SlingHttpServletRequest request, Writer out, String path, int nodeDepth) throws IOException, RepositoryException {}
 
     private static void accumulateShowHideExpressions(Node node, Map<String, String> map) throws RepositoryException {}
 

--- a/content/clientlib.config.js
+++ b/content/clientlib.config.js
@@ -18,10 +18,10 @@
  */
 module.exports = {
     context: __dirname,
-    clientLibRoot: "src/content/jcr_root/apps/core/wcm/components/commons/datalayer/v1/clientlibs",
     libs: [
         {
             name: "core.wcm.components.commons.datalayer.v1",
+            path: "src/content/jcr_root/apps/core/wcm/components/commons/datalayer/v1/clientlibs",
             serializationFormat: "xml",
             allowProxy: true,
             jsProcessor: ["default:none", "min:gcc;compilationLevel=whitespace"],
@@ -30,6 +30,31 @@ module.exports = {
                     "src/scripts/datalayer/v1/polyfill.js",
                     "node_modules/@adobe/adobe-client-data-layer/dist/adobe-client-data-layer.min.js",
                     "src/scripts/datalayer/v1/datalayer.js"
+                ]
+            }
+        },
+        {
+            name: "core.wcm.components.commons.datalayer.v2",
+            path: "src/content/jcr_root/apps/core/wcm/components/commons/datalayer/v2/clientlibs",
+            serializationFormat: "xml",
+            allowProxy: true,
+            jsProcessor: ["default:none", "min:gcc;compilationLevel=whitespace"],
+            assets: {
+                js: [
+                    "src/scripts/datalayer/v1/polyfill.js",
+                    "src/scripts/datalayer/v1/datalayer.js"
+                ]
+            }
+        },
+        {
+            name: "core.wcm.components.commons.datalayer.acdl",
+            path: "src/content/jcr_root/apps/core/wcm/components/commons/datalayer/acdl",
+            serializationFormat: "xml",
+            allowProxy: true,
+            jsProcessor: ["default:none", "min:gcc;compilationLevel=whitespace"],
+            assets: {
+                js: [
+                    "node_modules/@adobe/adobe-client-data-layer/dist/adobe-client-data-layer.min.js"
                 ]
             }
         }

--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -687,9 +687,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.11.17",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-            "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+            "version": "20.2.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.3.tgz",
+            "integrity": "sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==",
             "dev": true
         },
         "node_modules/@types/normalize-package-data": {
@@ -3024,9 +3024,9 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-            "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+            "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
             "dev": true,
             "dependencies": {
                 "@types/cookie": "^0.4.1",
@@ -3038,7 +3038,7 @@
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
                 "engine.io-parser": "~5.0.3",
-                "ws": "~8.2.3"
+                "ws": "~8.11.0"
             },
             "engines": {
                 "node": ">=10.0.0"
@@ -3111,6 +3111,27 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
+        },
+        "node_modules/engine.io/node_modules/ws": {
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/enquirer": {
             "version": "2.3.6",
@@ -8697,16 +8718,16 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-            "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+            "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
                 "debug": "~4.3.2",
-                "engine.io": "~6.2.1",
-                "socket.io-adapter": "~2.4.0",
+                "engine.io": "~6.4.1",
+                "socket.io-adapter": "~2.5.2",
                 "socket.io-parser": "~4.2.1"
             },
             "engines": {
@@ -8714,10 +8735,34 @@
             }
         },
         "node_modules/socket.io-adapter": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-            "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-            "dev": true
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+            "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+            "dev": true,
+            "dependencies": {
+                "ws": "~8.11.0"
+            }
+        },
+        "node_modules/socket.io-adapter/node_modules/ws": {
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/socket.io-client": {
             "version": "4.5.4",
@@ -11257,9 +11302,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "18.11.17",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-            "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+            "version": "20.2.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.3.tgz",
+            "integrity": "sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -13186,9 +13231,9 @@
             }
         },
         "engine.io": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-            "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+            "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
             "dev": true,
             "requires": {
                 "@types/cookie": "^0.4.1",
@@ -13200,7 +13245,7 @@
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
                 "engine.io-parser": "~5.0.3",
-                "ws": "~8.2.3"
+                "ws": "~8.11.0"
             },
             "dependencies": {
                 "debug": {
@@ -13217,6 +13262,13 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
+                },
+                "ws": {
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+                    "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+                    "dev": true,
+                    "requires": {}
                 }
             }
         },
@@ -17533,16 +17585,16 @@
             "dev": true
         },
         "socket.io": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-            "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+            "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
                 "debug": "~4.3.2",
-                "engine.io": "~6.2.1",
-                "socket.io-adapter": "~2.4.0",
+                "engine.io": "~6.4.1",
+                "socket.io-adapter": "~2.5.2",
                 "socket.io-parser": "~4.2.1"
             },
             "dependencies": {
@@ -17564,10 +17616,22 @@
             }
         },
         "socket.io-adapter": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-            "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-            "dev": true
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+            "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+            "dev": true,
+            "requires": {
+                "ws": "~8.11.0"
+            },
+            "dependencies": {
+                "ws": {
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+                    "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+                    "dev": true,
+                    "requires": {}
+                }
+            }
         },
         "socket.io-client": {
             "version": "4.5.4",

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -167,6 +167,8 @@
                         <exclude>**/node_modules/**</exclude>
                         <!-- Ignore generated datalayer clientlib -->
                         <exclude>**/core.wcm.components.commons.datalayer.v1/**</exclude>
+                        <exclude>**/core.wcm.components.commons.datalayer.v2/**</exclude>
+                        <exclude>**/core.wcm.components.commons.datalayer.acdl/**</exclude>
                         <!-- Ignore karma -->
                         <exclude>**/coverage/**</exclude>
                     </excludes>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
@@ -26,5 +26,6 @@
     <sly data-sly-test="${clientLibCategoriesJsHead}" data-sly-call="${clientlib.js @ categories=clientLibCategoriesJsHead, async=page.isClientlibsAsync}"></sly>
     <sly data-sly-test="${clientLibCategories}" data-sly-call="${clientlib.css @ categories=clientLibCategories}"></sly>
     <link data-sly-test="${staticDesignPath}" href="${staticDesignPath}" rel="stylesheet" type="text/css" />
-    <sly data-sly-test="${page.data && page.dataLayerClientlibIncluded}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v1', async=true}"></sly>
+    <sly data-sly-test="${page.data}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v2', async=true}"/>
+    <sly data-sly-test="${page.data && page.dataLayerClientlibIncluded}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.acdl', async=true}"/>
 </template>

--- a/extensions/amp/content/package-lock.json
+++ b/extensions/amp/content/package-lock.json
@@ -648,9 +648,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.11.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
-            "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==",
+            "version": "20.2.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.3.tgz",
+            "integrity": "sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==",
             "dev": true
         },
         "node_modules/@types/normalize-package-data": {
@@ -2380,9 +2380,9 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-            "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+            "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
             "dev": true,
             "dependencies": {
                 "@types/cookie": "^0.4.1",
@@ -2394,7 +2394,7 @@
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
                 "engine.io-parser": "~5.0.3",
-                "ws": "~8.2.3"
+                "ws": "~8.11.0"
             },
             "engines": {
                 "node": ">=10.0.0"
@@ -2435,27 +2435,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
-        },
-        "node_modules/engine.io-client/node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/engine.io-parser": {
             "version": "5.0.4",
@@ -6943,16 +6922,16 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-            "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+            "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
                 "debug": "~4.3.2",
-                "engine.io": "~6.2.1",
-                "socket.io-adapter": "~2.4.0",
+                "engine.io": "~6.4.1",
+                "socket.io-adapter": "~2.5.2",
                 "socket.io-parser": "~4.2.1"
             },
             "engines": {
@@ -6960,10 +6939,13 @@
             }
         },
         "node_modules/socket.io-adapter": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-            "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-            "dev": true
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+            "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+            "dev": true,
+            "dependencies": {
+                "ws": "~8.11.0"
+            }
         },
         "node_modules/socket.io-client": {
             "version": "4.6.1",
@@ -8380,9 +8362,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -9040,9 +9022,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "18.11.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
-            "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==",
+            "version": "20.2.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.3.tgz",
+            "integrity": "sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -10392,9 +10374,9 @@
             }
         },
         "engine.io": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-            "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+            "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
             "dev": true,
             "requires": {
                 "@types/cookie": "^0.4.1",
@@ -10406,7 +10388,7 @@
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
                 "engine.io-parser": "~5.0.3",
-                "ws": "~8.2.3"
+                "ws": "~8.11.0"
             },
             "dependencies": {
                 "debug": {
@@ -10453,13 +10435,6 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
-                },
-                "ws": {
-                    "version": "8.11.0",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-                    "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-                    "dev": true,
-                    "requires": {}
                 }
             }
         },
@@ -13861,16 +13836,16 @@
             "dev": true
         },
         "socket.io": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-            "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+            "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
                 "debug": "~4.3.2",
-                "engine.io": "~6.2.1",
-                "socket.io-adapter": "~2.4.0",
+                "engine.io": "~6.4.1",
+                "socket.io-adapter": "~2.5.2",
                 "socket.io-parser": "~4.2.1"
             },
             "dependencies": {
@@ -13892,10 +13867,13 @@
             }
         },
         "socket.io-adapter": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-            "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-            "dev": true
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+            "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+            "dev": true,
+            "requires": {
+                "ws": "~8.11.0"
+            }
         },
         "socket.io-client": {
             "version": "4.6.1",
@@ -14986,9 +14964,9 @@
             }
         },
         "ws": {
-            "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
             "dev": true,
             "requires": {}
         },

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -515,6 +515,11 @@
                     <url>https://repo.adobe.com/nexus/content/groups/public/</url>
                     <layout>default</layout>
                 </repository>
+                <repository>
+                    <id>central</id>
+                    <name>Maven Repository Switchboard</name>
+                    <url>http://repo1.maven.org/maven2</url>
+                </repository>
             </repositories>
 
             <pluginRepositories>
@@ -741,6 +746,13 @@
                 <groupId>com.adobe.cq.wcm</groupId>
                 <artifactId>com.adobe.aem.wcm.seo</artifactId>
                 <version>1.0.10</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.adobe.granite.bundles</groupId>
+                <artifactId>json</artifactId>
+                <version>20230618_2</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -517,8 +517,9 @@
                 </repository>
                 <repository>
                     <id>central</id>
-                    <name>Maven Repository Switchboard</name>
-                    <url>http://repo1.maven.org/maven2</url>
+                    <name>Central Repository</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <layout>default</layout>
                 </repository>
             </repositories>
 
@@ -527,6 +528,12 @@
                     <id>adobe-public-releases</id>
                     <name>Adobe Public Repository</name>
                     <url>https://repo.adobe.com/nexus/content/groups/public/</url>
+                    <layout>default</layout>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>central</id>
+                    <name>Central Repository</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
                     <layout>default</layout>
                 </pluginRepository>
             </pluginRepositories>

--- a/testing/aem-mock-plugin/src/main/java/com/adobe/cq/wcm/core/components/testing/mock/ContextPlugins.java
+++ b/testing/aem-mock-plugin/src/main/java/com/adobe/cq/wcm/core/components/testing/mock/ContextPlugins.java
@@ -20,6 +20,7 @@ import org.apache.sling.testing.mock.osgi.context.ContextPlugin;
 import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.internal.link.DefaultPathProcessor;
+import com.adobe.cq.wcm.core.components.internal.services.LatestVersionImplementationPicker;
 
 import io.wcm.testing.mock.aem.context.AemContextImpl;
 
@@ -49,7 +50,10 @@ public final class ContextPlugins {
     static void setUp(AemContextImpl context) {
 
         // register default path processor for core components link handling
-        context.registerInjectActivateService(new DefaultPathProcessor());
+        context.registerInjectActivateService(DefaultPathProcessor.class);
+
+        // sling models implementation picker for core component-specific version preferences
+        context.registerInjectActivateService(LatestVersionImplementationPicker.class);
 
     }
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes [`#2606`](https://github.com/adobe/aem-core-wcm-components/issues/2606)
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Tests Pass
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
- Since the non-deterministic order of `HashSet` causes the issue, we need to make it deterministic.
- This is done by changing the implementation of `categories` from `HashSet` to `LinkedHashSet`. 
- This ensures that the order of elements is maintained in their order of insertion similar to
https://github.com/adobe/aem-core-wcm-components/blob/0efca91f4b7b5f56a02fefabbdec273c8b77ffd8/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java#L324
