### PR TITLE
Fixed Non-deterministic behavior of HashSet that might fail tests in PageImplTest

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
@@ -131,6 +131,7 @@ public class PageImpl extends AbstractComponentImpl implements Page {
             title = currentPage.getName();
         }
         Tag[] tags = currentPage.getTags();
+        // sort to maintain the order of tag elements
         Arrays.sort(tags, Comparator.comparing(Tag::getName));
         keywords = new String[tags.length];
         int index = 0;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -130,6 +131,7 @@ public class PageImpl extends AbstractComponentImpl implements Page {
             title = currentPage.getName();
         }
         Tag[] tags = currentPage.getTags();
+        Arrays.sort(tags, Comparator.comparing(Tag::getName));
         keywords = new String[tags.length];
         int index = 0;
         for (Tag tag : tags) {

--- a/bundles/core/src/test/resources/page/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/exporter-templated-page.json
@@ -18,8 +18,8 @@
             "xdm:template": "/conf/coretest/settings/wcm/templates/product-page",
             "repo:path": "/core/content/page/templated-page.html",
             "xdm:tags": [
-                "three",
                 "one",
+                "three",
                 "two"
             ]
         }

--- a/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
@@ -72,8 +72,8 @@
       "xdm:template": "/conf/coretest/settings/wcm/templates/product-page",
       "xdm:language": "en-GB",
       "xdm:tags": [
-        "three",
         "one",
+        "three",
         "two"
       ],
       "repo:path": "/core/content/page/templated-page.html"

--- a/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
@@ -72,8 +72,8 @@
       "xdm:template": "/conf/coretest/settings/wcm/templates/product-page",
       "xdm:language": "en-GB",
       "xdm:tags": [
-        "three",
         "one",
+        "three",
         "two"
       ],
       "repo:path": "/core/content/page/templated-page.html"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes [`#2612`](https://github.com/adobe/aem-core-wcm-components/issues/2612)
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Tests Pass
| Documentation Provided   | No (Added Code Comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
- This is implementation of the 2nd proposed solution described in the `Proposed Solution` section of the issue.
- The tags of the page are sorted based on their names using `Arrays.sort()`.
- This ensures that elements of the `tags` remain consistent when exported to json.