### PR TITLE
Fixed Non-deterministic behavior of HashMap that might fail tests

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/NextGenDMImageURIBuilder.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/NextGenDMImageURIBuilder.java
@@ -15,7 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v3;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Scanner;
 
@@ -103,7 +103,7 @@ public class NextGenDMImageURIBuilder {
             imageDeliveryPath = imageDeliveryPath.replace(PATH_PLACEHOLDER_FORMAT, assetExtension);
             String repositoryId = this.config.getRepositoryId();
             StringBuilder uriBuilder = new StringBuilder("https://" + repositoryId + imageDeliveryPath);
-            Map<String, String> params = new HashMap<>();
+            Map<String, String> params = new LinkedHashMap<>();
             if(this.width > 0) {
                 params.put("width", Integer.toString(this.width));
             }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes [`#2619`](https://github.com/adobe/aem-core-wcm-components/issues/2619)
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Not Applicable
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
- As mentioned in the 'Proposed Solution' section of the [issue #2619](https://github.com/adobe/aem-core-wcm-components/issues/2619), the implementation of `params` Map is changed from `HashMap` to `LinkedHashMap`.
- This ensures that the order of parameters in the URI will be maintained in the order of insertion, which remains constant over time.